### PR TITLE
Fix dicom row /col sizing and remove SOPInstanceUID

### DIFF
--- a/pdf2dcm/base.py
+++ b/pdf2dcm/base.py
@@ -21,7 +21,6 @@ class BaseConverter(ABC):
             "PatientSex",
             "StudyInstanceUID",
             "SeriesInstanceUID",
-            "SOPInstanceUID",
         ]
 
     def personalize_dcm(
@@ -78,6 +77,7 @@ class BaseConverter(ABC):
 
         ds.is_little_endian = True
         ds.is_implicit_VR = False
+        ds.SOPInstanceUID = generate_uid()
 
         # if we want to create the pdf with the pdf creation timing
         dt = datetime.datetime.now()

--- a/pdf2dcm/pdf2rgb.py
+++ b/pdf2dcm/pdf2rgb.py
@@ -42,7 +42,7 @@ class Pdf2RgbSC(BaseConverter):
         Args:
             file_meta (FileMetaDataset): meta information of a dicom
             img (PIL Image): A PIL type rgb image to be stored as RGB SC Dicom
-            frameID (int): integer value of frameID to resutrn pages in single series
+            frameID (int): integer value of frameID to return pages in single series
 
         Returns:
             FileDataset: rgb sc dicom dataset

--- a/pdf2dcm/pdf2rgb.py
+++ b/pdf2dcm/pdf2rgb.py
@@ -54,8 +54,8 @@ class Pdf2RgbSC(BaseConverter):
         ds.BitsAllocated = 8
         ds.BitsStored = 8
         ds.HighBit = 7
-        ds.Rows = img.size[0]
-        ds.Columns = img.size[1]
+        ds.Rows = img.size[1]
+        ds.Columns = img.size[0]
         ds.add_new(0x00280006, "US", 0)
 
         ds.PixelData = img.tobytes()

--- a/pdf2dcm/pdf2rgb.py
+++ b/pdf2dcm/pdf2rgb.py
@@ -36,12 +36,13 @@ class Pdf2RgbSC(BaseConverter):
         file_meta.ImplementationClassUID = uid.RGB_SC_IMPL_CLASS_UID
         return file_meta
 
-    def generate_rgb_sc(self, file_meta: FileMetaDataset, img) -> FileDataset:
+    def generate_rgb_sc(self, file_meta: FileMetaDataset, img, frameID) -> FileDataset:
         """method to rgb sc pdf byte stream in a dicom
 
         Args:
             file_meta (FileMetaDataset): meta information of a dicom
             img (PIL Image): A PIL type rgb image to be stored as RGB SC Dicom
+            frameID (int): integer value of frameID to resutrn pages in single series
 
         Returns:
             FileDataset: rgb sc dicom dataset
@@ -57,6 +58,7 @@ class Pdf2RgbSC(BaseConverter):
         ds.Rows = img.size[1]
         ds.Columns = img.size[0]
         ds.add_new(0x00280006, "US", 0)
+        ds.InstanceNumber = frameID+1
 
         ds.PixelData = img.tobytes()
         ds.PixelRepresentation = 0
@@ -128,7 +130,7 @@ class Pdf2RgbSC(BaseConverter):
 
         for idx, page in enumerate(pages):
             store_dcm_path = Path(os.path.join(path, f"{name}_{idx}{suffix}"))
-            rgb_sc_dcm = self.generate_rgb_sc(rgbsc_meta, page)
+            rgb_sc_dcm = self.generate_rgb_sc(rgbsc_meta, page, idx)
             if personalisation:
                 rgb_sc_dcm = self.personalize_dcm(path_template_dcm_path, rgb_sc_dcm)
             dicom_pdf_file_paths.append(self._store_ds(store_dcm_path, rgb_sc_dcm))


### PR DESCRIPTION
Correct typo that incorrectly assigned wrong row and column size (note in the merge_pages method, assignment is correct). 
Removed SOPInstanceUID from personalize and assign with new generate_uid explicitly. Add InstanceNumber to force ordering for multipage pdf. 

Sorry about the multiple commits - not sure what happened there. 