### PR TITLE
Remove Dataset.is_little_endian/is_implicit_VR deprecated in pydicom 3

### DIFF
--- a/pdf2dcm/base.py
+++ b/pdf2dcm/base.py
@@ -4,7 +4,7 @@ from pydicom.dataset import FileMetaDataset, FileDataset, validate_file_meta
 from pydicom.errors import InvalidDicomError
 from abc import ABC, abstractmethod
 
-from pydicom.uid import generate_uid
+from pydicom.uid import generate_uid, ExplicitVRLittleEndian
 
 import tempfile
 from typing import List
@@ -58,9 +58,7 @@ class BaseConverter(ABC):
 
         file_meta = FileMetaDataset()
         file_meta.FileMetaInformationVersion = b"\x00\x01"
-        file_meta.TransferSyntaxUID = (
-            "1.2.840.10008.1.2.1"  # std transfer uid little endian, implicit vr
-        )
+        file_meta.TransferSyntaxUID = ExplicitVRLittleEndian
         file_meta.ImplementationVersionName = "pdf2dcm"
         return file_meta
 
@@ -77,8 +75,6 @@ class BaseConverter(ABC):
         filename = tempfile.NamedTemporaryFile().name
         ds = FileDataset(filename, {}, file_meta=meta, preamble=b"\0" * 128)
 
-        ds.is_little_endian = True
-        ds.is_implicit_VR = False
         ds.SOPInstanceUID = generate_uid()
 
         # if we want to create the pdf with the pdf creation timing


### PR DESCRIPTION
Hello, love this project!

I saw some warnings about deprecation, so I decided to contribute.

pydicom 3.0 deprecated `Dataset.is_little_endian` and `Dataset.is_implicit_VR` (removal planned for 4.0). 
They don't do anything here anymore - the encoding is picked from `file_meta.TransferSyntaxUID` since we save with
`enforce_file_format=True` - so I just dropped them.

See https://pydicom.github.io/pydicom/stable/release_notes/v3.0.0.html#deprecations

Thanks!